### PR TITLE
Add "Messrs" as abbreviation for "messieurs"

### DIFF
--- a/plugin/textobj/sentence.vim
+++ b/plugin/textobj/sentence.vim
@@ -42,6 +42,7 @@ if !exists('g:textobj#sentence#abbreviations')
     \ 'alt', '[Ee]tc', 'div', 'es[pt]', '[Ll]td', 'min',
     \ '[MD]rs', '[Aa]pt', '[Aa]ve?', '[Ss]tr?',
     \ '[Aa]ssn', '[Bb]lvd', '[Dd]ept', 'incl', 'Inst', 'Prof', 'Univ',
+    \ 'Messrs',
     \ ]
 endif
 


### PR DESCRIPTION
The Cambridge Advanced Learner's Dictionary & Thesaurus offers the following definition for "Messrs" (http://dictionary.cambridge.org/dictionary/english/messrs):
> plural of Mr (= title used before a man's name) used before the names of two or more men, usually in the title of a company:
> Messrs Wood and Laurence, solicitors